### PR TITLE
Added support for multi-device pools

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -101,7 +101,7 @@ void run(Map config, String projectArn, String sylphRunName,
       print(
           '\nStarting \'${testSuite['test_suite']}\' run \'$sylphRunName\' in project \'${config['project_name']}\' on pool \'$poolName\'...\n');
       // lookup device pool info in config file
-      Map devicePoolInfo = getDevicePoolInfo(config, poolName);
+      Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
 
       // Setup device pool
       String devicePoolArn = sylph.setupDevicePool(devicePoolInfo, projectArn);
@@ -127,9 +127,9 @@ void run(Map config, String projectArn, String sylphRunName,
       // get first device in device pool (currently supporting only one device per pool)
       final jobDevice = devicePoolInfo['devices'].first;
 
-      // construct artifacts dir for this device farm run
+      // construct artifacts dir for device farm run
       final runArtifactsDir = generateRunArtifactsDir(config['artifacts_dir'],
-          config['project_name'], sylphRunTimestamp, poolName, jobDevice);
+          sylphRunName, config['project_name'], poolName);
 
       // run tests and report
       runTests(
@@ -196,7 +196,7 @@ void runTests(
 
   // Download artifacts
   print('Downloading artifacts...');
-  sylph.downloadJobArtifacts(runArn, jobDevice, artifactsDir);
+  sylph.downloadJobArtifacts(runArn, artifactsDir);
 }
 
 void _handleError(ArgParser argParser, String msg) {

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -87,9 +87,11 @@ void run(Map config, String projectArn, String sylphRunName,
 //          'bundling test: $test on $poolType devices in device pool $poolName');
 //    }
 
+    // sylph staging dir
     final tmpDir = config['tmp_dir'];
+
     // Unpack resources used for building debug .ipa and to bundle tests
-    await unpackResources(tmpDir); // todo: remove here or in bundler
+    await unpackResources(tmpDir);
 
     // Bundle tests
     await bundleFlutterTests(config);

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -45,14 +45,15 @@ main(List<String> arguments) async {
     _handleError(argParser, "File not found: $configFilePath");
   }
 
-  final sylphRunTimeout = 720; // todo: allow different timeouts
   final timestamp = genTimestamp();
-  final sylphRunName = 'sylph run at $timestamp'; // todo: allow different names
+  final sylphRunName = 'sylph run at $timestamp';
   print('Starting Sylph run \'$sylphRunName\' on AWS Device Farm ...');
   print('Config file: $configFilePath');
 
   // Parse config file
   Map config = await sylph.parseYaml(configFilePath);
+
+  final sylphRunTimeout = config['sylph_timeout'];
 
   // Setup project (if needed)
   final projectArn =

--- a/lib/bundle.dart
+++ b/lib/bundle.dart
@@ -23,9 +23,6 @@ Future<void> bundleFlutterTests(Map config) async {
 
   print('Creating test bundle for upload...');
 
-  // create fresh staging area
-  await unpackResources(stagingDir); // again
-
   // unzip template into test bundle dir
   cmd('unzip', ['-q', appiumTemplatePath, '-d', testBundleDir], '.', false);
 

--- a/test/sylph_test.yaml
+++ b/test/sylph_test.yaml
@@ -11,18 +11,26 @@ default_job_timeout: 5 # minutes
 tmp_dir: /tmp/sylph
 
 device_pools:
-    - pool_name: android pool 1
-      pool_type: android
-      devices:
-        - name: Samsung Galaxy S9 (Unlocked)
-          model: SM-G960U1
-          os: 8.0.0
-    - pool_name: ios pool 1
-      pool_type: ios
-      devices:
-        - name: Apple iPhone X
-          model: A1865
-          os: 12.0
+
+  - pool_name: android pool 1
+    pool_type: android
+    devices:
+#      - name: Samsung Galaxy S9 (Unlocked)
+#        model: SM-G960U1
+#        os: 8.0.0
+      - name: Google Pixel
+        model: Pixel
+        os: 8.0.0
+      - name: Google Pixel 2
+        model: Google Pixel 2
+        os: 8.0.0
+
+  - pool_name: ios pool 1
+    pool_type: ios
+    devices:
+      - name: Apple iPhone X
+        model: A1865
+        os: 12.0
 
 test_suites:
   - test_suite: my tests 1


### PR DESCRIPTION
At the end of a run on a pool with multiple devices, artifacts from the job run on each device are download separately and stored under 
```
<sylph artifacts dir>/<sylph run id>/<project name>/<pool name>/<device descriptor>
```

Also
- fixed problem with creating multi-device pools
- sylph time out is configurable from sylph.yaml
- refactored to separate handling of a sylph device and a device farm device
- tested from local mac

Fixes #15 
See #8