### PR TITLE
Added reporting of test progress per device in pool

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -83,7 +83,7 @@ void sylphRun(Map config, String projectArn, String sylphRunName,
   await bundleFlutterTests(config);
 
   for (var testSuite in config['test_suites']) {
-    print('Running \'${testSuite['test_suite']}\' test suite...');
+    print('\nRunning \'${testSuite['test_suite']}\' test suite...\n');
 
     // todo: update test spec with tests in test suite
     // (currently only allows one test)
@@ -97,7 +97,7 @@ void sylphRun(Map config, String projectArn, String sylphRunName,
     // Initialize device pools and run tests in each pool
     for (final poolName in testSuite['pool_names']) {
       print(
-          '\nStarting \'${testSuite['test_suite']}\' run \'$sylphRunName\' in project \'${config['project_name']}\' on pool \'$poolName\'...\n');
+          'Running test suite \'${testSuite['test_suite']}\'  in project \'${config['project_name']}\' on pool \'$poolName\'...');
       // lookup device pool info in config file
       Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
 
@@ -136,7 +136,8 @@ void sylphRun(Map config, String projectArn, String sylphRunName,
           testPackageArn,
           testSpecArn,
           runArtifactsDir,
-          testSuite['job_timeout']);
+          testSuite['job_timeout'],
+          poolName);
     }
   }
 }
@@ -176,14 +177,15 @@ void runTests(
     String testPackageArn,
     String testSpecArn,
     String artifactsDir,
-    int jobTimeout) {
+    int jobTimeout,
+    poolName) {
   // Schedule run
   print('Starting run \'$runName\' on AWS Device Farms...');
   String runArn = sylph.scheduleRun(runName, projectArn, appArn, devicePoolArn,
       testSpecArn, testPackageArn, jobTimeout);
 
   // Monitor run progress
-  final run = sylph.runStatus(runArn, sylphRunTimeout);
+  final run = sylph.runStatus(runArn, sylphRunTimeout, poolName);
 
   // Output run result
   sylph.runReport(run);

--- a/example/sylph.yaml
+++ b/example/sylph.yaml
@@ -5,21 +5,27 @@
 # Then monitors tests, returns final pass/fail result and downloads artifacts.
 # Note: assumes the 'aws' command line utility is logged-in.
 
-project_name: example flutter tests 2
-default_job_timeout: 7 # minutes, set at project creation
-
+# sylph config
 tmp_dir: /tmp/sylph
-
 artifacts_dir: /tmp/sylph_artifacts
+# local timeout per device farm run
+sylph_timeout: 720 # seconds approx
+
+# device farm config
+project_name: test artifacts download
+default_job_timeout: 7 # minutes, set at project creation
 
 device_pools:
 
   - pool_name: android pool 1
     pool_type: android
     devices:
-#      - name: Samsung Galaxy S9 (Unlocked)
-#        model: SM-G960U1
-#        os: 8.0.0
+      - name: Samsung Galaxy S9 (Unlocked)
+        model: SM-G960U1
+        os: 8.0.0
+      - name: Google Pixel
+        model: Pixel
+        os: 8.0.0
       - name: Google Pixel 2
         model: Google Pixel 2
         os: 8.0.0
@@ -27,9 +33,13 @@ device_pools:
   - pool_name: ios pool 1
     pool_type: ios
     devices:
-      - name: Apple iPhone X
-        model: A1865
-        os: 12.0
+
+  - pool_name: iPhone 5c
+    pool_type: ios
+    devices:
+      - name: Apple iPhone 5c
+        model: A1532
+        os: 10.3.1
 
 test_suites:
 
@@ -38,7 +48,8 @@ test_suites:
     testspec: test_driver/test_spec.yaml
     tests:
       - test_driver/main_test.dart
-    device_pools:
+    pool_names:
       - android pool 1
       - ios pool 1
-    job_timeout: 7 # minutes, set per job
+      - iPhone 5c
+    job_timeout: 5 # minutes, set per job

--- a/lib/bundle.dart
+++ b/lib/bundle.dart
@@ -14,7 +14,7 @@ const kBuildToOsMapFileName = 'build_to_os.txt';
 /// Bundles Flutter tests using appium template found in staging area.
 /// Resulting bundle is saved on disk in temporary location
 /// for later upload.
-Future<void> bundleFlutterTests(Map config) async {
+Future<int> bundleFlutterTests(Map config) async {
   final stagingDir = config['tmp_dir'];
   final appiumTemplatePath = '$stagingDir/$kAppiumTemplateName';
   final testBundleDir = '$stagingDir/$kTestBundleDir';
@@ -58,12 +58,15 @@ Future<void> bundleFlutterTests(Map config) async {
           1024)
       .round();
   print('Test bundle created (size $size MB)');
+
+  return size;
 }
 
 /// Unpacks resources found in package into [tmpDir].
 /// Appium template is used to deliver tests.
 /// Scripts are used to initialize device and run tests.
 Future<void> unpackResources(String tmpDir) async {
+  print('Unpacking sylph resources to $tmpDir');
   clearDirectory(tmpDir);
 
   // unpack Appium template

--- a/lib/sylph.dart
+++ b/lib/sylph.dart
@@ -173,8 +173,8 @@ void runReport(Map run) {
   }
 }
 
-/// Finds the ARNs of devices
-/// Returns device ARNs as a [List]
+/// Finds the ARNs of devices for a [List] of sylph devices.
+/// Returns device ARNs as a [List].
 List findDevicesArns(List sylphDevices) {
   final deviceArns = [];
   // get all devices
@@ -192,7 +192,7 @@ List findDevicesArns(List sylphDevices) {
   return deviceArns;
 }
 
-/// Converts a list of sylph devices [sylphDevices] to a rule.
+/// Converts a [List] of sylph devices to a rule.
 /// Used for building a device pool.
 /// Returns rule as formatted [String].
 String devicesToRule(List sylphDevices) {

--- a/lib/sylph.dart
+++ b/lib/sylph.dart
@@ -196,7 +196,6 @@ List findDevicesArns(List sylphDevices) {
 /// Used for building a device pool.
 /// Returns rule as formatted [String].
 String devicesToRule(List sylphDevices) {
-  // convert devices to rule
   return '[{"attribute": "ARN", "operator": "IN","value": "[${formatArns(findDevicesArns(sylphDevices))}]"}]';
 }
 
@@ -236,18 +235,6 @@ String uploadFile(String projectArn, String filePath, String fileType) {
 void downloadJobArtifacts(String runArn, String runArtifactDir) {
   // list jobs
   final List jobs = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
-//  // check only one job and on expected device then download artifacts
-//  if (jobs.length == 1) {
-//    final job = jobs.first;
-//    // confirm job is on expected device
-//    if (isJobOnDevice(job, jobDevice)) {
-//      downloadArtifacts(job['arn'], jobDownloadDir);
-//    } else {
-//      throw ('Error: job not on expected device: ${deviceDesc(jobDevice)}');
-//    }
-//  } else {
-//    throw ('Error: multiple jobs found where one expected: $jobs');
-//  }
 
   for (final job in jobs) {
     // get sylph device
@@ -265,6 +252,7 @@ void downloadJobArtifacts(String runArn, String runArtifactDir) {
 /// Downloads artifacts generated during a run.
 /// [arn] can be a run, job, suite, or test ARN.
 void downloadArtifacts(String arn, String artifactsDir) {
+  print('Downloading artifacts to $artifactsDir');
   // create directory
   clearDirectory(artifactsDir);
 
@@ -285,7 +273,6 @@ void downloadArtifacts(String arn, String artifactsDir) {
     // use last artifactID to make unique
     final fileName = '$name ${artifactIDs[3]}.$extension'.replaceAll(' ', '_');
     final filePath = '$artifactsDir/$fileName';
-    print(filePath);
     cmd('wget', ['-O', filePath, fileUrl]);
   }
 }

--- a/lib/sylph.dart
+++ b/lib/sylph.dart
@@ -63,8 +63,7 @@ String setupDevicePool(Map devicePoolInfo, String projectArn) {
   if (pool == null) {
     // create new device pool
     print('Creating new device pool \'$poolName\' ...');
-    // convert devices to rules
-//    List rules = devicesToRules(devices);
+    // convert devices to a rule
     String rules = devicesToRule(devices);
 
     final newPool = deviceFarmCmd([
@@ -74,7 +73,6 @@ String setupDevicePool(Map devicePoolInfo, String projectArn) {
       '--project-arn',
       projectArn,
       '--rules',
-//      jsonEncode(rules),
       rules,
       // number of devices in pool should not exceed number of devices requested
       // An error occurred (ArgumentException) when calling the CreateDevicePool operation: A static device pool can not have max devices parameter
@@ -175,19 +173,6 @@ void runReport(Map run) {
   }
 }
 
-/// Finds the ARN of a device.
-/// Returns device ARN  as [String].
-String findDeviceArn(Map sylphDevice) {
-  final jobDevices = deviceFarmCmd([
-    'list-devices',
-  ])['devices'];
-  Map jobDevice = jobDevices.firstWhere(
-      (device) => (isDeviceEqual(device, sylphDevice)),
-      orElse: () =>
-          throw 'Error: device does not exist: ${deviceDesc(sylphDevice)}');
-  return jobDevice['arn'];
-}
-
 /// Finds the ARNs of devices
 /// Returns device ARNs as a [List]
 List findDevicesArns(List sylphDevices) {
@@ -205,21 +190,6 @@ List findDevicesArns(List sylphDevices) {
   }
 
   return deviceArns;
-}
-
-/// Converts a list of sylph devices [sylphDevices] to a list of rules.
-/// Used for building a device pool.
-/// Returns rules as [List].
-List devicesToRules(List sylphDevices) {
-  // convert devices to rules
-  final List rules = sylphDevices
-      .map((sylphDevice) => {
-            'attribute': 'ARN',
-            'operator': 'IN',
-            'value': '[\"' + findDeviceArn(sylphDevice) + '\"]'
-          })
-      .toList();
-  return rules;
 }
 
 /// Converts a list of sylph devices [sylphDevices] to a rule.

--- a/lib/sylph.dart
+++ b/lib/sylph.dart
@@ -116,7 +116,7 @@ String scheduleRun(
 /// Tracks run status.
 /// Returns final run status as [Map].
 // todo: add per job status (test on each device in pool) to run status
-Map runStatus(String runArn, int sylphRunTimeout) {
+Map runStatus(String runArn, int sylphRunTimeout, String poolName) {
   const timeoutIncrement = 2;
   Map runStatus;
   for (int i = 0; i < sylphRunTimeout; i += timeoutIncrement) {
@@ -129,7 +129,7 @@ Map runStatus(String runArn, int sylphRunTimeout) {
 
     // print run status
     print(
-        'Run status: $runStatusFlag (sylph run timeout: $i of $sylphRunTimeout)');
+        'Run status on device pool \'$poolName\`: $runStatusFlag (sylph run timeout: $i of $sylphRunTimeout)');
 
     if (runStatusFlag == kCompletedRunStatus) return runStatus;
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -24,7 +24,7 @@ Future<void> writeFileImage(List<int> fileImage, String path) async {
 /// Returns stdout as [String].
 String cmd(String cmd, List<String> arguments,
     [String workingDir = '.', bool silent = true]) {
-  print('cmd=\'$cmd ${arguments.join(" ")}\'');
+//  print('cmd=\'$cmd ${arguments.join(" ")}\'');
   final result = Process.runSync(cmd, arguments, workingDirectory: workingDir);
   if (!silent) stdout.write(result.stdout);
   if (result.exitCode != 0) {
@@ -98,18 +98,6 @@ String deviceDesc(Map device) {
   return 'name=${device['name']}, model=${device['model']}, os=${device['os']}';
 }
 
-/// checks if job running on correct device
-//bool isJobOnDevice(Map job, Map device) {
-//  final deviceFarmDevice = job['device'];
-//  if (deviceFarmDevice['model'] == device['name'] &&
-//      deviceFarmDevice['modelId'] == device['model'] &&
-//      deviceFarmDevice['os'] == device['os']) {
-//    return true;
-//  } else {
-//    return false;
-//  }
-//}
-
 /// generates a download directory for each Device Farm run's artifacts
 String generateRunArtifactsDir(String downloadDirPrefix, String sylphRunName,
     String projectName, String poolName) {
@@ -135,17 +123,8 @@ Map getSylphDevice(jobDevice) {
   };
 }
 
-///// Compares a jobDevice to a sylph device
-//bool isDeviceEqual(Map device, String name, String model, String os) {
-//  return device['name'] == name &&
-//      device['modelId'] == model &&
-//      device['os'] == os;
-//}
-
 /// Compares a jobDevice to a sylph device
 bool isDeviceEqual(Map jobDevice, Map sylphDevice) {
-//  print('jobDevice=$jobDevice');
-//  print('sylphDevice=$sylphDevice');
   return jobDevice['name'] == sylphDevice['name'] &&
       jobDevice['modelId'] == sylphDevice['model'] &&
       jobDevice['os'] == sylphDevice['os'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   args: ^1.5.1
   yaml: ^2.1.15
   resource: ^2.1.5
+  sprintf: ^4.0.2
 
 dev_dependencies:
   test: ^1.0.0

--- a/test/sylph_test.dart
+++ b/test/sylph_test.dart
@@ -84,7 +84,9 @@ void main() {
     final projectName = 'flutter test';
     final jobTimeoutMinutes = 5;
     final result = setupProject(projectName, jobTimeoutMinutes);
-    print(result);
+    final expected =
+        'arn:aws:devicefarm:us-west-2:122621792560:project:c43f0049-7b2f-42ed-9e4b-c6c46de9de23';
+    expect(result, expected);
   });
 
   test('find device ARN', () {
@@ -99,7 +101,7 @@ void main() {
         'arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E');
   });
 
-  test('convert devices to rules', () {
+  test('convert devices to a rule', () {
     final List devices = [
       {'name': 'Apple iPhone X', 'model': 'A1865', 'os': '12.0'},
       {'name': 'Google Pixel', 'model': 'Pixel', 'os': '8.0.0'}
@@ -107,18 +109,9 @@ void main() {
 
     // convert devices to rules
     final rules = devicesToRule(devices);
-    print(rules);
-  });
-
-  test('convert devices to a rule', () {
-    final List devices = [
-      {'name': 'Apple iPhone X', 'model': 'A1865', 'os': '12.0'},
-      {'name': 'Google Pixel', 'model': 'Pixel', 'os': '8.0.0'}
-    ];
-
-    // convert devices to rule
-    final rule = devicesToRule(devices);
-    print(jsonEncode(rule));
+    final expected =
+        '[{"attribute": "ARN", "operator": "IN","value": "[\\"arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E\\",\\"arn:aws:devicefarm:us-west-2::device:6B26991B2257455788C5B8EA3C9F91C4\\"]"}]';
+    expect(rules, expected);
   });
 
   test('setup device pool', () async {
@@ -135,9 +128,10 @@ void main() {
     Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
 
     // check for existing pool
-    String result = setupDevicePool(devicePoolInfo, projectArn);
-
-    print(result);
+    final result = setupDevicePool(devicePoolInfo, projectArn);
+    final expected =
+        'arn:aws:devicefarm:us-west-2:122621792560:devicepool:e1c97f71-f534-432b-9e86-3bd7529e327b/762d6c56-e189-43ca-aded-bf59c7e20904';
+    expect(result, expected);
   });
 
   test('monitor run progress until complete', () {
@@ -157,13 +151,15 @@ void main() {
   });
 
   test('bundle flutter test', () async {
-//    final filePath = 'test/sylph_test.yaml';
-    final filePath = 'example/sylph.yaml';
+    final filePath = 'test/sylph_test.yaml';
+//    final filePath = 'example/sylph.yaml';
     final config = await parseYaml(filePath);
     // change directory to app
     final origDir = Directory.current;
     Directory.current = 'example';
-    await bundleFlutterTests(config);
+    await unpackResources(config['tmp_dir']);
+    final bundleSize = await bundleFlutterTests(config);
+    expect(bundleSize, 5);
     // change back for tests to continue
     Directory.current = origDir;
   });
@@ -174,7 +170,17 @@ void main() {
 //    print('config=$config');
 
     final List testSuites = config['test_suites'];
-    print('testSuites=$testSuites');
+    final expectedSuites = [
+      {
+        'tests': ['lib/main.dart'],
+        'pool_names': ['android pool 1'],
+        'testspec': 'test_spec.yaml',
+        'job_timeout': 5,
+        'app_path': '/Users/jenkins/flutter_app',
+        'test_suite': 'my tests 1'
+      }
+    ];
+    expect(testSuites, expectedSuites);
     for (var testSuite in testSuites) {
       print('Running ${testSuite['test_suite']} ...');
       final List devicePools = testSuite['pool_names'];
@@ -198,27 +204,13 @@ void main() {
     final filePath = 'test/sylph_test.yaml';
     final config = await parseYaml(filePath);
 
-    //    for (var pools in devicePools) {
-//      if (devicePool != null) return;
-//      final List poolList = pools;
-//      print('poolList=$poolList');
-//      devicePool = poolList.firstWhere((pool) {
-//        print(pool['device_pool_name']);
-//        return pool['device_pool_name'] == poolName;
-//      }, orElse: () => null);
-//      print('devicePool=$devicePool');
-//    }
-
     final poolName = 'android pool 1';
     Map devicePool = getDevicePoolInfo(config['device_pools'], poolName);
     final expected = {
       'pool_type': 'android',
       'devices': [
-        {
-          'model': 'SM-G960U1',
-          'name': 'Samsung Galaxy S9 (Unlocked)',
-          'os': '8.0.0'
-        }
+        {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'},
+        {'model': 'Google Pixel 2', 'name': 'Google Pixel 2', 'os': '8.0.0'}
       ],
       'pool_name': 'android pool 1'
     };
@@ -230,8 +222,6 @@ void main() {
     final config = await parseYaml(filePath);
     final poolName = 'android pool 1';
     Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
-    print('resulting devicePool=$devicePoolInfo');
-
     expect(devicePoolInfo['pool_type'], enumToStr(DeviceType.android));
   });
 
@@ -258,7 +248,6 @@ void main() {
     final project = projects.firstWhere(
         (project) => project['name'] == projectName,
         orElse: () => null);
-    print(project);
     expect(project['name'], projectName);
   });
 
@@ -272,10 +261,10 @@ void main() {
     // download each artifact
     final sylphRunTimestamp = genTimestamp();
     final sylphRunName = 'dummy sylph run $sylphRunTimestamp';
-    final projectName = 'example flutter tests 2';
+    final runName = 'sylph run at 2019-06-23 23:44:16.214';
+    final projectName = 'test artifacts download';
     final poolName = 'pool 1'; // only used in dir path
     final downloadDirPrefix = '/tmp/sylph artifacts';
-    final runStartDate = 1561183228.503; // a successful run on ios
 
     // list projects
     final projects = deviceFarmCmd(['list-projects'])['projects'];
@@ -286,26 +275,25 @@ void main() {
         orElse: () => null);
     final projectArn = project['arn'];
     expect(projectArn,
-        'arn:aws:devicefarm:us-west-2:122621792560:project:25b6693b-ecdc-40b6-b736-29de562c18b9');
+        'arn:aws:devicefarm:us-west-2:122621792560:project:e1c97f71-f534-432b-9e86-3bd7529e327b');
 
     // list runs
     final runs = deviceFarmCmd(['list-runs', '--arn', projectArn])['runs'];
 //    print('runs=$runs');
     // get a run
-    final run = runs.firstWhere((run) => '${run['created']}' == '$runStartDate',
+    final run = runs.firstWhere((run) => '${run['name']}' == runName,
         orElse: () => null);
     final runArn = run['arn'];
     expect(runArn,
-        'arn:aws:devicefarm:us-west-2:122621792560:run:25b6693b-ecdc-40b6-b736-29de562c18b9/db578606-ebc4-4c1e-a72e-a14b30cbe898');
+        'arn:aws:devicefarm:us-west-2:122621792560:run:e1c97f71-f534-432b-9e86-3bd7529e327b/50e59618-6925-45aa-87f6-c5184ef62407');
 
     // list jobs
     final List jobs = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
+    expect(jobs.length, 2);
 
-    // get a job (use first for this test)
-    final job = jobs.first;
-    final jobArn = job['arn'];
-    expect(jobArn,
-        'arn:aws:devicefarm:us-west-2:122621792560:job:25b6693b-ecdc-40b6-b736-29de562c18b9/db578606-ebc4-4c1e-a72e-a14b30cbe898/00000');
+    // get job (use first for this test)
+    expect(jobs.first['arn'],
+        'arn:aws:devicefarm:us-west-2:122621792560:job:e1c97f71-f534-432b-9e86-3bd7529e327b/50e59618-6925-45aa-87f6-c5184ef62407/00000');
 
     // generate run download dir
     String runDownloadDir = generateRunArtifactsDir(
@@ -321,11 +309,7 @@ void main() {
     final config = await parseYaml(filePath);
     final devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
     final devices = devicePoolInfo['devices'];
-    final expected = {
-      'model': 'SM-G960U1',
-      'name': 'Samsung Galaxy S9 (Unlocked)',
-      'os': '8.0.0'
-    };
+    final expected = {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'};
     expect(devices.first, expected);
   });
 }

--- a/test/sylph_test.dart
+++ b/test/sylph_test.dart
@@ -106,8 +106,8 @@ void main() {
     ];
 
     // convert devices to rules
-    List rules = devicesToRules(devices);
-    print(jsonEncode(rules));
+    final rules = devicesToRule(devices);
+    print(rules);
   });
 
   test('convert devices to a rule', () {

--- a/test/sylph_test.dart
+++ b/test/sylph_test.dart
@@ -314,7 +314,7 @@ void main() {
     final jobsInfo = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
     for (final jobInfo in jobsInfo) {
 //      print('jobInfo=$jobInfo');
-      print('\t\t${jobProgress(jobInfo)}');
+      print('\t\t${jobStatus(jobInfo)}');
     }
   });
 }

--- a/test/sylph_test.dart
+++ b/test/sylph_test.dart
@@ -288,7 +288,7 @@ void main() {
     final List jobs = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
     expect(jobs.length, 2);
 
-    // get job (use first for this test)
+    // confirm first job
     expect(jobs.first['arn'], kFirstJobArn);
 
     // generate run download dir
@@ -307,5 +307,14 @@ void main() {
     final devices = devicePoolInfo['devices'];
     final expected = {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'};
     expect(devices.first, expected);
+  });
+
+  test('generate job progress report for current run', () {
+    final runArn = kSuccessfulRunArn;
+    final jobsInfo = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
+    for (final jobInfo in jobsInfo) {
+//      print('jobInfo=$jobInfo');
+      print('\t\t${jobProgress(jobInfo)}');
+    }
   });
 }


### PR DESCRIPTION
Show test progress on each device (device time, pass/fail, etc...) during a run.

Also:
- track success/fail of sylph run across multiple device farm runs and report at end
- fixed tests
- bundle tests once only 
- added demo of getting app id from a .apk (for future `flutter -no-build` enhancement)
- some refactoring and cleanup and improved messaging

Fixes #19 
