### PR TITLE
Fixed multiple tests not running on android devices

### DIFF
--- a/lib/resources/script/local_utils.sh
+++ b/lib/resources/script/local_utils.sh
@@ -40,9 +40,9 @@ where:
 # install certificate and provisioning profile using match
 # assumes resources unbundled from sylph
 # note: expects PUBLISHING_MATCH_CERTIFICATE_REPO in format
-# ssh://git@private.mycompany.com:1234/timecar/certificates.git
+# ssh://git@private.mycompany.com:1234/private_repos/match.git
 # instead of
-# https://matchusername:matchpassword@private.mycompany.com/private_repos/match
+# https://matchusername:matchpassword@private.mycompany.com/private_repos/match.git
 config_ci() {
   local app_dir=$1
 
@@ -57,6 +57,7 @@ EOF
 
   # add MATCH_HOST public key to known hosts
   ssh-keyscan -t ecdsa -p "$MATCH_PORT" "$MATCH_HOST" >> ~/.ssh/known_hosts
+  # note: for additional security ssh keys can be generated on CI build machine
   chmod 600 "$app_dir/dummy-ssh-keys/key"
   chmod 700 "$app_dir/dummy-ssh-keys"
 

--- a/lib/resources/script/test_ios.sh
+++ b/lib/resources/script/test_ios.sh
@@ -84,32 +84,10 @@ dummy_symbols() {
   done < "$dummy_symbols_path"
 }
 
-#run_tests() {
-#  local debug_app_path=$1
-#  shift
-#  local tests=($@)
-#  for test in "${tests[@]}"
-#  do
-#    run_driver "$debug_app_path" "$test"
-#  done
-#}
-
-#run_tests() {
-#  local debug_app_path=$1
-#  readarray -t -d, tests <<<"$2,"; unset 'tests[-1]'; declare -p tests;
-#  for test in "${tests[@]}"
-#  do
-##  echo "test=$test"
-#    run_driver "$debug_app_path" "$test"
-#  done
-#}
-
-
 run_tests() {
  local debug_app_path=$1
  while IFS=',' read -ra tests; do
     for test in "${tests[@]}"; do
-#      echo "test=$test"
       run_driver "$debug_app_path" "$test"
     done
   done <<< "$2"


### PR DESCRIPTION
Fix for subsequent tests (after first test) not running on android devices. Had to release the appium port used for forwarding (port 4723) and clear the device log to avoid picking-up a prior observatory announcement in the device log.

Also
- did some cleanup on other scripts

fixes #31