### PR TITLE
Added feature to support configuring a device pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ or, if not using the default config file:
 sylph -c <path to config file>
 ```
 
+General usage:
+```
+usage: sylph [--help] [--config <config file>] [--devices <all|android|ios>]
+
+sample usage: sylph
+
+-c, --config=<sylph.yaml>          Path to config file.
+                                   (defaults to "sylph.yaml")
+
+-d, --devices=<all|android|ios>    List availabe devices.
+                                   [all, android, ios]
+
+    --help                         Display this help information.
+```
+
+# Dependencies
+## AWS CLI
+Install AWS Command Line Interface (AWS CLI)
+```
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+``` 
+For alternative install options see:  
+https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+
+## AWS CLI Credentials
+Configure the AWS CLI credentials:
+```
+$ aws configure
+AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+Default region name [None]: us-west-2
+Default output format [None]: json
+```
+For alternative configuration options see:  
+https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+
 # Configuration
 All configuration information is passed to _Sylph_ using a configuration file. The default config file is called `sylph.yaml`:
 ```yaml
@@ -53,48 +91,30 @@ device_pools:
 test_suites:
 
   - test_suite: example tests 1
-    main: test_driver/main1.dart
+    main: test_driver/main.dart
     tests:
-      - test_driver/main1_test1.dart
-      - test_driver/main1_test2.dart
+      - test_driver/main_test1.dart
+      - test_driver/main_test2.dart
     device_pools:
       - android pool 1
       - ios pool 1
     job_timeout: 5 # minutes per each device run
-    
-  - test_suite: example tests 2
-    main: test_driver/main2.dart
-    tests:
-      - test_driver/main2_test1.dart
-      - test_driver/main2_test2.dart
-    pool_names:
-      - android pool 1
-      - ios pool 1
-    job_timeout: 5 # minutes per each device run
 ```
+Multiple test suites, consisting of multiple tests, can be run on each device in each device pool. The 'main' app must include a call to `enableFlutterDriverExtension()`. 
 
-# Dependencies
-## AWS CLI
-Install AWS Command Line Interface (AWS CLI)
-```
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-unzip awscli-bundle.zip
-sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-``` 
-For alternative install options see:  
-https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+Device pools can consist of multiple devices. Devices in a device pool must be of the same type, iOS or Android.
 
-## AWS CLI Credentials
-Configure the AWS CLI credentials:
+## Populating a device pool
+To add devices to a device pool, pick devices from the list provided by
 ```
-$ aws configure
-AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
-AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-Default region name [None]: us-west-2
-Default output format [None]: json
+sylph -d android
+or
+sylph -d ios
 ```
-For alternative configuration options see:  
-https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
+and add to the appropriate pool type in sylph.yaml. The listed devices are devices currently available on Device Farm.
+
+## Configuration Validation
+The sylph.yaml is validated to confirm the devices are  available on Device Farm and tests are present before starting a run.
 
 # Configuring a CI Environment for _Sylph_
 

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 import 'package:sylph/sylph.dart';
 import 'package:args/args.dart';
 
-const usage = 'usage: sylph [--help] [--config <config file>]';
+const usage =
+    'usage: sylph [--help] [--config <config file>] [--devices <all|android|ios>]';
 const sampleUsage = 'sample usage: sylph';
 
 /// Uploads debug app and integration test to device farm and runs test.
@@ -11,6 +12,7 @@ main(List<String> arguments) async {
   ArgResults argResults;
 
   final configArg = 'config';
+  final devicesArg = 'devices';
   final helpArg = 'help';
   final ArgParser argParser = new ArgParser(allowTrailingOptions: false)
     ..addOption(configArg,
@@ -18,6 +20,11 @@ main(List<String> arguments) async {
         defaultsTo: 'sylph.yaml',
         help: 'Path to config file.',
         valueHelp: 'sylph.yaml')
+    ..addOption(devicesArg,
+        abbr: 'd',
+        help: 'List availabe devices.',
+        allowed: ['all', 'android', 'ios'],
+        valueHelp: 'all|android|ios')
     ..addFlag(helpArg,
         help: 'Display this help information.', negatable: false);
   try {
@@ -27,8 +34,32 @@ main(List<String> arguments) async {
   }
 
   // show help
-  if (argResults[helpArg]) {
+  if (argResults[helpArg] ||
+      (argResults.wasParsed(configArg) && argResults.wasParsed(configArg))) {
     _showUsage(argParser);
+    exit(0);
+  }
+
+  // show devices
+  final devicesArgVal = argResults[devicesArg];
+  if (devicesArgVal != null) {
+    switch (devicesArgVal) {
+      case 'all':
+        for (final sylphDevice in getSylphDevices()) {
+          print(sylphDevice);
+        }
+        break;
+      case 'android':
+        for (final sylphDevice in getDevices(DeviceType.android)) {
+          print(sylphDevice);
+        }
+        break;
+      case 'ios':
+        for (final sylphDevice in getDevices(DeviceType.ios)) {
+          print(sylphDevice);
+        }
+        break;
+    }
     exit(0);
   }
 

--- a/lib/src/device_farm.dart
+++ b/lib/src/device_farm.dart
@@ -4,8 +4,6 @@ import 'package:sprintf/sprintf.dart';
 
 import 'utils.dart';
 
-enum DeviceType { ios, android }
-
 const kUploadTimeout = 5;
 const kUploadSucceeded = 'SUCCEEDED';
 const kCompletedRunStatus = 'COMPLETED';
@@ -284,9 +282,4 @@ void downloadArtifacts(String arn, String artifactsDir) {
     final filePath = '$artifactsDir/$fileName';
     cmd('wget', ['-O', filePath, fileUrl]);
   }
-}
-
-/// Converts [DeviceType] to [String]
-String deviceTypeStr(DeviceType deviceType) {
-  return DeviceType.ios.toString().split('.')[1];
 }

--- a/lib/src/devices.dart
+++ b/lib/src/devices.dart
@@ -1,0 +1,50 @@
+import 'package:version/version.dart';
+
+import 'utils.dart';
+
+enum DeviceType { ios, android }
+
+Iterable getDevices(DeviceType deviceType) {
+  return getSylphDevices().where((device) => device.deviceType == deviceType);
+}
+
+List getSylphDevices() {
+  final devices = deviceFarmCmd(['list-devices'])['devices'];
+  final sylphDevices = [];
+  for (final device in devices) {
+    sylphDevices.add(SylphDevice(
+        device['name'],
+        device['modelId'],
+        Version.parse(device['os']),
+        device['platform'] == 'ANDROID' ? DeviceType.android : DeviceType.ios));
+  }
+  sylphDevices.sort();
+  return sylphDevices;
+}
+
+class SylphDevice implements Comparable {
+  SylphDevice(this.name, this.model, this.os, this.deviceType);
+  final String name, model;
+  final Version os;
+  final DeviceType deviceType;
+
+  @override
+  String toString() {
+    return 'name:$name, model:$model, os:$os, deviceType:${enumToStr(deviceType)}';
+  }
+
+  @override
+  int compareTo(other) {
+    final nameCompare = name.compareTo(other.name);
+    if (nameCompare != 0) {
+      return nameCompare;
+    } else {
+      final modelCompare = model.compareTo(other.model);
+      if (modelCompare != 0) {
+        return modelCompare;
+      } else {
+        return os == other.os ? 0 : os > other.os ? 1 : -1;
+      }
+    }
+  }
+}

--- a/lib/sylph.dart
+++ b/lib/sylph.dart
@@ -1,2 +1,3 @@
 export 'src/device_farm.dart';
 export 'src/sylph_run.dart';
+export 'src/devices.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   isolate: ^2.0.2
   collection: ^1.14.11
   duration: ^2.0.8
+  version: ^1.0.3
 
 dev_dependencies:
   test: ^1.0.0

--- a/test/sylph_test.dart
+++ b/test/sylph_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:sylph/src/bundle.dart';
 import 'package:sylph/src/concurrent_jobs.dart';
 import 'package:sylph/src/device_farm.dart';
+import 'package:sylph/src/devices.dart';
 import 'package:sylph/src/sylph_run.dart';
 import 'package:sylph/src/utils.dart';
 import 'package:sylph/src/validator.dart';
@@ -20,26 +21,27 @@ const kFirstJobArn =
     'arn:aws:devicefarm:us-west-2:122621792560:job:e1c97f71-f534-432b-9e86-3bd7529e327b/50e59618-6925-45aa-87f6-c5184ef62407/00000';
 
 void main() {
-  test('parse yaml', () async {
-    final filePath = 'test/sylph_test.yaml';
-    await parseYaml(filePath);
-  });
+  group('initial tests', () {
+    test('parse yaml', () async {
+      final filePath = 'test/sylph_test.yaml';
+      await parseYaml(filePath);
+    });
 
-  test('get first poolname and devices', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final config = await parseYaml(filePath);
+    test('get first poolname and devices', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final config = await parseYaml(filePath);
 //    print('config=$config');
-    final poolName = config['device_pools'][1]['pool_name'];
-    final devices = config['device_pools'][1]['devices'];
-    expect(poolName, 'ios pool 1');
-    expect(devices, [
-      {'model': 'A1865', 'name': 'Apple iPhone X', 'os': 12.0},
+      final poolName = config['device_pools'][1]['pool_name'];
+      final devices = config['device_pools'][1]['devices'];
+      expect(poolName, 'ios pool 1');
+      expect(devices, [
+        {'model': 'A1865', 'name': 'Apple iPhone X', 'os': 12.0},
 //      {'model': 'A1865xxx', 'name': 'Apple iPhone 7', 'os': '12.0xxx'}
-    ]);
-  });
+      ]);
+    });
 
-  test('parse yaml from string', () async {
-    String deviceFarmConfigStr = '''
+    test('parse yaml from string', () async {
+      String deviceFarmConfigStr = '''
     aws_user: user1
     aws_pass: pass1
 
@@ -63,350 +65,378 @@ void main() {
         app: ~/flutter_app
         tests:
           - lib/main.dart''';
-    final expected = {
-      "aws_user": "user1",
-      "project": "ios_test",
-      "test_suites": [
-        {
-          "app": "~/flutter_app",
-          "tests": ["lib/main.dart"],
-          "device_pool": {
-            "android": null,
-            "ios": ["Apple iPhone X"]
+      final expected = {
+        "aws_user": "user1",
+        "project": "ios_test",
+        "test_suites": [
+          {
+            "app": "~/flutter_app",
+            "tests": ["lib/main.dart"],
+            "device_pool": {
+              "android": null,
+              "ios": ["Apple iPhone X"]
+            },
+            "test_suite": "my tests 1"
           },
-          "test_suite": "my tests 1"
-        },
-        {
-          "app": "~/flutter_app",
-          "tests": ["lib/main.dart"],
-          "test_suite": "my tests 2"
+          {
+            "app": "~/flutter_app",
+            "tests": ["lib/main.dart"],
+            "test_suite": "my tests 2"
+          }
+        ],
+        "aws_pass": "pass1",
+        "device_pool": {
+          "android": null,
+          "ios": ["Apple iPhone X"]
         }
-      ],
-      "aws_pass": "pass1",
-      "device_pool": {
-        "android": null,
-        "ios": ["Apple iPhone X"]
-      }
-    };
-    final Map deviceFarmConfig = loadYaml(deviceFarmConfigStr);
-    expect(deviceFarmConfig, expected);
-  });
+      };
+      final Map deviceFarmConfig = loadYaml(deviceFarmConfigStr);
+      expect(deviceFarmConfig, expected);
+    });
 
-  test('setup project', () {
-    final projectName = 'flutter test';
-    final jobTimeoutMinutes = 5;
-    final result = setupProject(projectName, jobTimeoutMinutes);
-    final expected =
-        'arn:aws:devicefarm:us-west-2:122621792560:project:c43f0049-7b2f-42ed-9e4b-c6c46de9de23';
-    expect(result, expected);
-  });
+    test('setup project', () {
+      final projectName = 'flutter test';
+      final jobTimeoutMinutes = 5;
+      final result = setupProject(projectName, jobTimeoutMinutes);
+      final expected =
+          'arn:aws:devicefarm:us-west-2:122621792560:project:c43f0049-7b2f-42ed-9e4b-c6c46de9de23';
+      expect(result, expected);
+    });
 
-  test('find device ARN', () {
-    final sylphDevice = {
-      'name': 'Apple iPhone X',
-      'model': 'A1865',
-      'os': '12.0'
+    test('find device ARN', () {
+      final sylphDevice = {
+        'name': 'Apple iPhone X',
+        'model': 'A1865',
+        'os': '12.0'
 //      'os': '11.4'
-    };
+      };
 
-    final result = findDevicesArns([sylphDevice]);
-    expect(result.length, 1);
-    expect(result.first,
-        'arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E');
-  });
+      final result = findDevicesArns([sylphDevice]);
+      expect(result.length, 1);
+      expect(result.first,
+          'arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E');
+    });
 
-  test('convert devices to a rule', () {
-    final List devices = [
-      {'name': 'Apple iPhone X', 'model': 'A1865', 'os': '12.0'},
-      {'name': 'Google Pixel', 'model': 'Pixel', 'os': '8.0.0'}
-    ];
+    test('convert devices to a rule', () {
+      final List devices = [
+        {'name': 'Apple iPhone X', 'model': 'A1865', 'os': '12.0'},
+        {'name': 'Google Pixel', 'model': 'Pixel', 'os': '8.0.0'}
+      ];
 
-    // convert devices to rules
-    final rules = devicesToRule(devices);
-    final expected =
-        '[{"attribute": "ARN", "operator": "IN","value": "[\\"arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E\\",\\"arn:aws:devicefarm:us-west-2::device:6B26991B2257455788C5B8EA3C9F91C4\\"]"}]';
-    expect(rules, expected);
-  });
+      // convert devices to rules
+      final rules = devicesToRule(devices);
+      final expected =
+          '[{"attribute": "ARN", "operator": "IN","value": "[\\"arn:aws:devicefarm:us-west-2::device:D125AEEE8614463BAE106865CAF4470E\\",\\"arn:aws:devicefarm:us-west-2::device:6B26991B2257455788C5B8EA3C9F91C4\\"]"}]';
+      expect(rules, expected);
+    });
 
-  test('setup device pool', () async {
+    test('setup device pool', () async {
 //    final projectArn =
 //        'arn:aws:devicefarm:us-west-2:122621792560:project:fb4de03d-c6ac-4d25-bd27-4a59214d2a8b';
-    // 'test artifacts download'
-    final projectArn =
-        'arn:aws:devicefarm:us-west-2:122621792560:project:e1c97f71-f534-432b-9e86-3bd7529e327b';
-    final poolName = 'ios pool 1';
-    final configFilePath = 'test/sylph_test.yaml';
+      // 'test artifacts download'
+      final projectArn =
+          'arn:aws:devicefarm:us-west-2:122621792560:project:e1c97f71-f534-432b-9e86-3bd7529e327b';
+      final poolName = 'ios pool 1';
+      final configFilePath = 'test/sylph_test.yaml';
 
-    Map config = await parseYaml(configFilePath);
+      Map config = await parseYaml(configFilePath);
 
-    Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
+      Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
 
-    // check for existing pool
-    final result = setupDevicePool(devicePoolInfo, projectArn);
-    final expected =
-        'arn:aws:devicefarm:us-west-2:122621792560:devicepool:e1c97f71-f534-432b-9e86-3bd7529e327b/ab9460cf-fd81-4848-9ae5-643da98937ae';
-    expect(result, expected);
-  });
+      // check for existing pool
+      final result = setupDevicePool(devicePoolInfo, projectArn);
+      final expected =
+          'arn:aws:devicefarm:us-west-2:122621792560:devicepool:e1c97f71-f534-432b-9e86-3bd7529e327b/ab9460cf-fd81-4848-9ae5-643da98937ae';
+      expect(result, expected);
+    });
 
-  test('monitor successful run progress until complete', () {
-    final timeout = 100;
-    final poolName = 'dummy pool name';
-    final result = runStatus(kSuccessfulRunArn, timeout, poolName);
+    test('monitor successful run progress until complete', () {
+      final timeout = 100;
+      final poolName = 'dummy pool name';
+      final result = runStatus(kSuccessfulRunArn, timeout, poolName);
 
-    // generate report
-    runReport(result);
-  });
+      // generate report
+      runReport(result);
+    });
 
-  test('bundle flutter test', () async {
-    final filePath = 'test/sylph_test.yaml';
+    test('bundle flutter test', () async {
+      final filePath = 'test/sylph_test.yaml';
 //    final filePath = 'example/sylph.yaml';
-    final config = await parseYaml(filePath);
-    // change directory to app
-    final origDir = Directory.current;
-    Directory.current = 'example';
-    await unpackResources(config['tmp_dir']);
-    final bundleSize = await bundleFlutterTests(config);
-    expect(bundleSize, 5);
-    // change back for tests to continue
-    Directory.current = origDir;
-  });
+      final config = await parseYaml(filePath);
+      // change directory to app
+      final origDir = Directory.current;
+      Directory.current = 'example';
+      await unpackResources(config['tmp_dir']);
+      final bundleSize = await bundleFlutterTests(config);
+      expect(bundleSize, 5);
+      // change back for tests to continue
+      Directory.current = origDir;
+    });
 
-  test('iterate thru test suites', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final config = await parseYaml(filePath);
+    test('iterate thru test suites', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final config = await parseYaml(filePath);
 //    print('config=$config');
 
-    final List testSuites = config['test_suites'];
-    final expectedSuites = [
-      {
-        'tests': ['lib/main.dart'],
-        'pool_names': ['android pool 1'],
-        'testspec': 'test_spec.yaml',
-        'job_timeout': 5,
-        'app_path': '/Users/jenkins/flutter_app',
-        'test_suite': 'my tests 1'
-      }
-    ];
-    expect(testSuites, expectedSuites);
-    for (var testSuite in testSuites) {
-      print('Running ${testSuite['test_suite']} ...');
-      final List devicePools = testSuite['pool_names'];
-      for (var poolName in devicePools) {
+      final List testSuites = config['test_suites'];
+      final expectedSuites = [
+        {
+          'tests': ['lib/main.dart'],
+          'pool_names': ['android pool 1'],
+          'testspec': 'test_spec.yaml',
+          'job_timeout': 5,
+          'app_path': '/Users/jenkins/flutter_app',
+          'test_suite': 'my tests 1'
+        }
+      ];
+      expect(testSuites, expectedSuites);
+      for (var testSuite in testSuites) {
+        print('Running ${testSuite['test_suite']} ...');
+        final List devicePools = testSuite['pool_names'];
+        for (var poolName in devicePools) {
 //        print('poolType=$poolType, poolName=$poolName');
-        final List tests = testSuite['tests'];
-        for (var test in tests) {
-          // lookup device pool
-          Map devicePool = getDevicePoolInfo(config['device_pools'], poolName);
-          if (devicePool == null) {
-            throw 'Exception: device pool $poolName not found';
+          final List tests = testSuite['tests'];
+          for (var test in tests) {
+            // lookup device pool
+            Map devicePool =
+                getDevicePoolInfo(config['device_pools'], poolName);
+            if (devicePool == null) {
+              throw 'Exception: device pool $poolName not found';
+            }
+            final poolType = devicePool['pool_type'];
+            print(
+                'running test: $test on $poolType devices in device pool $poolName');
           }
-          final poolType = devicePool['pool_type'];
-          print(
-              'running test: $test on $poolType devices in device pool $poolName');
         }
       }
-    }
-  });
-  test('lookup device pool', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final config = await parseYaml(filePath);
+    });
+    test('lookup device pool', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final config = await parseYaml(filePath);
 
-    final poolName = 'android pool 1';
-    Map devicePool = getDevicePoolInfo(config['device_pools'], poolName);
-    final expected = {
-      'pool_type': 'android',
-      'devices': [
-        {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'},
-        {'model': 'Google Pixel 2', 'name': 'Google Pixel 2', 'os': '8.0.0'}
-      ],
-      'pool_name': 'android pool 1'
-    };
-    expect(devicePool, expected);
-  });
+      final poolName = 'android pool 1';
+      Map devicePool = getDevicePoolInfo(config['device_pools'], poolName);
+      final expected = {
+        'pool_type': 'android',
+        'devices': [
+          {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'},
+          {'model': 'Google Pixel 2', 'name': 'Google Pixel 2', 'os': '8.0.0'}
+        ],
+        'pool_name': 'android pool 1'
+      };
+      expect(devicePool, expected);
+    });
 
-  test('check pool type', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final config = await parseYaml(filePath);
-    final poolName = 'android pool 1';
-    Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
-    expect(devicePoolInfo['pool_type'], enumToStr(DeviceType.android));
-  });
+    test('check pool type', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final config = await parseYaml(filePath);
+      final poolName = 'android pool 1';
+      Map devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
+      expect(devicePoolInfo['pool_type'], enumToStr(DeviceType.android));
+    });
 
-  test('download artifacts by run', () {
-    // get project arn
-    // aws devicefarm list-projects
-    // get project runs
-    // aws devicefarm list-runs --arn <project arn>
-    // get artifacts by run, by test suite, by test, etc..
-    // aws devicefarm list-artifacts --arn <run arn>
-    // download each artifact
-    DateTime timestamp = sylphTimestamp();
-    final downloadDir = '/tmp/tmp/artifacts xxx $timestamp';
-    // list artifacts
-    downloadArtifacts(kSuccessfulRunArn, downloadDir);
-  });
+    test('download artifacts by run', () {
+      // get project arn
+      // aws devicefarm list-projects
+      // get project runs
+      // aws devicefarm list-runs --arn <project arn>
+      // get artifacts by run, by test suite, by test, etc..
+      // aws devicefarm list-artifacts --arn <run arn>
+      // download each artifact
+      DateTime timestamp = sylphTimestamp();
+      final downloadDir = '/tmp/tmp/artifacts xxx $timestamp';
+      // list artifacts
+      downloadArtifacts(kSuccessfulRunArn, downloadDir);
+    });
 
-  test('run device farm command', () {
-    final projectName = 'flutter tests';
-    var projectInfo = deviceFarmCmd(['list-projects']);
-    final projects = projectInfo['projects'];
-    final project = projects.firstWhere(
-        (project) => project['name'] == projectName,
-        orElse: () => null);
-    expect(project['name'], projectName);
-  });
+    test('run device farm command', () {
+      final projectName = 'flutter tests';
+      var projectInfo = deviceFarmCmd(['list-projects']);
+      final projects = projectInfo['projects'];
+      final project = projects.firstWhere(
+          (project) => project['name'] == projectName,
+          orElse: () => null);
+      expect(project['name'], projectName);
+    });
 
-  test('download artifacts by job', () {
-    // get project arn
-    // aws devicefarm list-projects
-    // get project runs
-    // aws devicefarm list-runs --arn <project arn>
-    // get artifacts by run, by test suite, by test, etc..
-    // aws devicefarm list-artifacts --arn <run arn>
-    // download each artifact
-    final sylphRunTimestamp = sylphTimestamp();
-    final sylphRunName = 'dummy sylph run $sylphRunTimestamp';
-    final runName = 'sylph run at 2019-06-23 23:44:16.214'; // multiple jobs
-    final projectName = kTestProjectName;
-    final poolName = 'dummy pool 1'; // only used in dir path
-    final downloadDirPrefix = '/tmp/sylph artifacts';
+    test('download artifacts by job', () {
+      // get project arn
+      // aws devicefarm list-projects
+      // get project runs
+      // aws devicefarm list-runs --arn <project arn>
+      // get artifacts by run, by test suite, by test, etc..
+      // aws devicefarm list-artifacts --arn <run arn>
+      // download each artifact
+      final sylphRunTimestamp = sylphTimestamp();
+      final sylphRunName = 'dummy sylph run $sylphRunTimestamp';
+      final runName = 'sylph run at 2019-06-23 23:44:16.214'; // multiple jobs
+      final projectName = kTestProjectName;
+      final poolName = 'dummy pool 1'; // only used in dir path
+      final downloadDirPrefix = '/tmp/sylph artifacts';
 
-    // list projects
-    final projects = deviceFarmCmd(['list-projects'])['projects'];
+      // list projects
+      final projects = deviceFarmCmd(['list-projects'])['projects'];
 
-    // get project arn
-    final project = projects.firstWhere(
-        (project) => project['name'] == projectName,
-        orElse: () => null);
-    final projectArn = project['arn'];
-    expect(projectArn, kTestProjectArn);
+      // get project arn
+      final project = projects.firstWhere(
+          (project) => project['name'] == projectName,
+          orElse: () => null);
+      final projectArn = project['arn'];
+      expect(projectArn, kTestProjectArn);
 
-    // list runs
-    final runs = deviceFarmCmd(['list-runs', '--arn', projectArn])['runs'];
+      // list runs
+      final runs = deviceFarmCmd(['list-runs', '--arn', projectArn])['runs'];
 //    print('runs=$runs');
-    // get a run
-    final run = runs.firstWhere((run) => '${run['name']}' == runName,
-        orElse: () => null);
-    final runArn = run['arn'];
-    expect(runArn, kSuccessfulRunArn);
+      // get a run
+      final run = runs.firstWhere((run) => '${run['name']}' == runName,
+          orElse: () => null);
+      final runArn = run['arn'];
+      expect(runArn, kSuccessfulRunArn);
 
-    // list jobs
-    final List jobs = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
-    expect(jobs.length, 2);
+      // list jobs
+      final List jobs = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
+      expect(jobs.length, 2);
 
-    // confirm first job
-    expect(jobs.first['arn'], kFirstJobArn);
+      // confirm first job
+      expect(jobs.first['arn'], kFirstJobArn);
 
-    // generate run download dir
-    String runDownloadDir = runArtifactsDirPath(
-        downloadDirPrefix, sylphRunName, projectName, poolName);
+      // generate run download dir
+      String runDownloadDir = runArtifactsDirPath(
+          downloadDirPrefix, sylphRunName, projectName, poolName);
 
-    // download job artifacts
-    downloadJobArtifacts(runArn, runDownloadDir);
-  });
+      // download job artifacts
+      downloadJobArtifacts(runArn, runDownloadDir);
+    });
 
-  test('get first device in pool', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final poolName = 'android pool 1';
-    final config = await parseYaml(filePath);
-    final devicePoolInfo = getDevicePoolInfo(config['device_pools'], poolName);
-    final devices = devicePoolInfo['devices'];
-    final expected = {'model': 'Pixel', 'name': 'Google Pixel', 'os': '8.0.0'};
-    expect(devices.first, expected);
-  });
+    test('get first device in pool', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final poolName = 'android pool 1';
+      final config = await parseYaml(filePath);
+      final devicePoolInfo =
+          getDevicePoolInfo(config['device_pools'], poolName);
+      final devices = devicePoolInfo['devices'];
+      final expected = {
+        'model': 'Pixel',
+        'name': 'Google Pixel',
+        'os': '8.0.0'
+      };
+      expect(devices.first, expected);
+    });
 
-  test('generate job progress report for current run', () {
-    final runArn = kSuccessfulRunArn;
-    final jobsInfo = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
-    for (final jobInfo in jobsInfo) {
+    test('generate job progress report for current run', () {
+      final runArn = kSuccessfulRunArn;
+      final jobsInfo = deviceFarmCmd(['list-jobs', '--arn', runArn])['jobs'];
+      for (final jobInfo in jobsInfo) {
 //      print('jobInfo=$jobInfo');
-      print('\t\t${jobStatus(jobInfo)}');
-    }
-  });
+        print('\t\t${jobStatus(jobInfo)}');
+      }
+    });
 
-  test('run jobs in parallel', () async {
-    final jobArgs = [
-      {'n': 10},
-      {'n': 20}
-    ];
+    test('run jobs in parallel', () async {
+      final jobArgs = [
+        {'n': 10},
+        {'n': 20}
+      ];
 //    print('square=$square');
-    List results = await runJobs(square, jobArgs);
-    for (int i = 0; i < results.length; i++) {
+      List results = await runJobs(square, jobArgs);
+      for (int i = 0; i < results.length; i++) {
 //      print("square job #$i: job(${jobArgs[i]}) = ${results[i]}");
-      expect(results[i], square(jobArgs[i]));
-    }
+        expect(results[i], square(jobArgs[i]));
+      }
 
-    // try again with a future
-    results = await runJobs(squareFuture, jobArgs);
-    for (int i = 0; i < results.length; i++) {
+      // try again with a future
+      results = await runJobs(squareFuture, jobArgs);
+      for (int i = 0; i < results.length; i++) {
 //      print("squareFuture job #$i: job(${jobArgs[i]}) = ${results[i]}");
-      expect(results[i], await squareFuture(jobArgs[i]));
-    }
-  });
+        expect(results[i], await squareFuture(jobArgs[i]));
+      }
+    });
 
-  test('run sylph tests on a device pool in isolate', () async {
-    final config = await parseYaml('test/sylph_test.yaml');
+    test('run sylph tests on a device pool in isolate', () async {
+      final config = await parseYaml('test/sylph_test.yaml');
 
-    // pack job args
-    //Map testSuite, Map config, poolName,
-    //    String projectArn, String sylphRunName, int sylphRunTimeout
-    final timestamp = sylphTimestamp();
-    final testSuite = config['test_suites'].first;
-    final poolName = 'android pool 1';
-    final projectArn = kTestProjectArn;
-    final sylphRunName = 'dummy sylph run $timestamp';
-    final sylphRunTimeout = config['sylph_timeout'];
-    final jobArgs = packArgs(
-        testSuite, config, poolName, projectArn, sylphRunName, sylphRunTimeout);
+      // pack job args
+      //Map testSuite, Map config, poolName,
+      //    String projectArn, String sylphRunName, int sylphRunTimeout
+      final timestamp = sylphTimestamp();
+      final testSuite = config['test_suites'].first;
+      final poolName = 'android pool 1';
+      final projectArn = kTestProjectArn;
+      final sylphRunName = 'dummy sylph run $timestamp';
+      final sylphRunTimeout = config['sylph_timeout'];
+      final jobArgs = packArgs(testSuite, config, poolName, projectArn,
+          sylphRunName, sylphRunTimeout);
 
-    // run
-    final result = await runJobs(runSylphJobInIsolate, [jobArgs]);
-    expect(result, [
-      {'result': true}
-    ]);
-  });
+      // run
+      final result = await runJobs(runSylphJobInIsolate, [jobArgs]);
+      expect(result, [
+        {'result': true}
+      ]);
+    });
 
-  test('are all sylph devices found', () async {
-    // get all sylph devices from sylph.yaml
+    test('are all sylph devices found', () async {
+      // get all sylph devices from sylph.yaml
 //    final config = await parseYaml('test/sylph_test.yaml');
-    final config = await parseYaml('example/sylph.yaml');
-    // for this test change directory
-    final origDir = Directory.current;
-    Directory.current = 'example';
-    final allSylphDevicesFound = isValidConfig(config);
-    expect(allSylphDevicesFound, true);
-    // allow other tests to continue
-    Directory.current = origDir;
-  });
+      final config = await parseYaml('example/sylph.yaml');
+      // for this test change directory
+      final origDir = Directory.current;
+      Directory.current = 'example';
+      final allSylphDevicesFound = isValidConfig(config);
+      expect(allSylphDevicesFound, true);
+      // allow other tests to continue
+      Directory.current = origDir;
+    });
 
-  test('sylph duration', () {
-    final runTime =
-        Duration(hours: 0, minutes: 15, seconds: 34, milliseconds: 123);
-    final endTime = DateTime.now().add(runTime);
-    final startTime = sylphTimestamp();
+    test('sylph duration', () {
+      final runTime =
+          Duration(hours: 0, minutes: 15, seconds: 34, milliseconds: 123);
+      final endTime = DateTime.now().add(runTime);
+      final startTime = sylphTimestamp();
 
-    String durationFormatted = sylphRuntimeFormatted(startTime, endTime);
-    // rounds to milliseconds
-    expect(durationFormatted.contains(RegExp(r'15m:34s:12.ms')), true);
-  });
+      String durationFormatted = sylphRuntimeFormatted(startTime, endTime);
+      // rounds to milliseconds
+      expect(durationFormatted.contains(RegExp(r'15m:34s:12.ms')), true);
+    });
 
-  test('substitute MAIN and TESTS for actual debug main and tests', () async {
-    final filePath = 'test/sylph_test.yaml';
-    final config = await parseYaml(filePath);
-    final test_suite = config['test_suites'][0];
-    final expectedMainEnvVal = test_suite['main'];
-    final expectedTestsEnvVal = test_suite['tests'].join(",");
-    final testSpecPath = 'test/test_spec_test.yaml';
-    final expected = '''
+    test('substitute MAIN and TESTS for actual debug main and tests', () async {
+      final filePath = 'test/sylph_test.yaml';
+      final config = await parseYaml(filePath);
+      final test_suite = config['test_suites'][0];
+      final expectedMainEnvVal = test_suite['main'];
+      final expectedTestsEnvVal = test_suite['tests'].join(",");
+      final testSpecPath = 'test/test_spec_test.yaml';
+      final expected = '''
       # - bin/py.test tests/ --junit-xml \$DEVICEFARM_LOG_DIR/junitreport.xml
       - MAIN=$expectedMainEnvVal
       - TESTS='$expectedTestsEnvVal'
       - cd flutter_app
 ''';
-    setTestSpecEnv(test_suite, testSpecPath);
-    expect(File(testSpecPath).readAsStringSync(), expected);
-    // restore modified test spec test
-    cmd('git', ['checkout', testSpecPath]);
+      setTestSpecEnv(test_suite, testSpecPath);
+      expect(File(testSpecPath).readAsStringSync(), expected);
+      // restore modified test spec test
+      cmd('git', ['checkout', testSpecPath]);
+    });
+  });
+
+  group('device search', () {
+    test('get all devices', () {
+      List sylphDevices = getSylphDevices();
+      for (final sylphDevice in sylphDevices) {
+        print('sylphDevice=$sylphDevice');
+      }
+    });
+
+    test('get android devices', () {
+      for (final androidDevice in getDevices(DeviceType.android)) {
+        print('androidDevice=$androidDevice');
+      }
+    });
+
+    test('get ios devices', () {
+      for (final iOSDevice in getDevices(DeviceType.ios)) {
+        print('iOSDevice=$iOSDevice');
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Added feature to support configuring a device pool. Lists devices currently available on Device Farm. The info presented for each device matches the info required to add a device to a pool in the sylph.yaml. User can select devices from the list and insert into sylph.yaml. An existing validator will confirm devices are currently available at the start of each run.

Updated README with instructions on how to use new feature.

Fixes #35