### PR TITLE
Released v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0
+- Added support for bundling local packages #59
+- Added code coverage #53
+- Added form factor (phone/tablet) to device listing feature. Sorting by phone then table. #52 #53
+- Added tracking error code when running on device farm. #45
+- Removed dependency on env vars when not building for iOS. #41
+
 ## 0.4.0
 - Fixed multiple tests not running on android devices. #31
 - Added feature to support configuring a device pool. #35  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sylph
 description: A utility for running Flutter integration tests on pools of real devices in cloud. Works with AWS Device Farms.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/mmcc007/sylph
 author: Maurice McCabe <mmcc007@gmail.com>
 


### PR DESCRIPTION
- Added support for bundling local packages #59
- Added code coverage #53
- Added form factor (phone/tablet) to device listing feature. Sorting by phone then table. #52 #53
- Added tracking error code when running on device farm. #45
- Removed dependency on env vars when not building for iOS. #41

Also fixes #63 