### PR TITLE
Allow global paths for Mac users

### DIFF
--- a/lib/src/base/local_packages.dart
+++ b/lib/src/base/local_packages.dart
@@ -85,8 +85,10 @@ class LocalPackageManager {
                   pkgInfo[kLocalDependencyPath] = pkgPath;
                 } else {
                   // copy local package
-                  final pkgSrcDir =
-                      path.joinAll([srcDir, path.joinAll(v.split('/'))]);
+                  // if we have a global path for our local packages, remove the first "."
+                  final auxSrcDir = v.contains("/Users/") ? "/" : srcDir;
+                  path.joinAll([srcDir, path.joinAll(v.split('/'))]);
+                  final pkgSrcDir = path.joinAll([auxSrcDir, path.joinAll(v.split('/'))]);
                   final pkgDstDir = path.join(dstDir, pkgName);
                   copy(pkgSrcDir, pkgDstDir);
                   // install any local packages within this local package


### PR DESCRIPTION
This PR will allow local paths in the `pubspec.yaml` file for Mac users.

Which means that the following is now allowed:

```yaml
  tutorial_coach_mark:
    path: /path/to/tutorial_coach_mark
```

Since I do not have access to a Linux or Windows machine, I'd be greatly appreciated for some feedback in how to include these platforms in the PR