### PR TITLE
Remove `.packages` before test

### DIFF
--- a/lib/resources/test_spec.yaml
+++ b/lib/resources/test_spec.yaml
@@ -16,6 +16,8 @@ phases:
 
       # enter flutter app directory in Appium bundle
       - cd flutter_app
+      # Delete .packages to avoid error setting file modification time (bonus: get rid of the mismatched Flutter repo warning)
+      - rm -f .packages
       - ls -la
 
       # check for bash


### PR DESCRIPTION
This PR deletes the `.packages` file inside `flutter_app` before running test. This has to be done with recent version of Flutter otherwise **sylph** will failed with this `flutter_01.log` file:

## command

flutter packages get

## exception

FileSystemException: FileSystemException: Failed to set file modification time, path = '/tmp/scratchDnVoiY.scratch/test-packagexLJOuq/flutter_app/.packages' (OS Error: Operation not permitted, errno = 1)

```
#0      _File.setLastModifiedSync (dart:io/file_impl.dart:473:7)
#1      ForwardingFile.setLastModifiedSync (package:file/src/forwarding/forwarding_file.dart:62:55)
#2      _DefaultPub.get (package:flutter_tools/src/dart/pub.dart:211:19)
<asynchronous suspension>
#3      PackagesGetCommand._runPubGet (package:flutter_tools/src/commands/packages.dart:98:17)
#4      PackagesGetCommand.runCommand (package:flutter_tools/src/commands/packages.dart:128:11)
#5      FlutterCommand.verifyThenRunCommand (package:flutter_tools/src/runner/flutter_command.dart:615:18)
#6      _asyncThenWrapperHelper.<anonymous closure> (dart:async-patch/async_patch.dart:73:64)
#7      _rootRunUnary (dart:async/zone.dart:1134:38)
#8      _CustomZone.runUnary (dart:async/zone.dart:1031:19)
#9      _FutureListener.handleValue (dart:async/future_impl.dart:139:18)
#10     Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:680:45)
#11     Future._propagateToListeners (dart:async/future_impl.dart:709:32)
#12     Future._completeWithValue (dart:async/future_impl.dart:524:5)
#13     Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:554:7)
#14     _rootRun (dart:async/zone.dart:1126:13)
#15     _CustomZone.run (dart:async/zone.dart:1023:19)
#16     _CustomZone.runGuarded (dart:async/zone.dart:925:7)
#17     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:965:23)
#18     _microtaskLoop (dart:async/schedule_microtask.dart:43:21)
#19     _startMicrotaskLoop (dart:async/schedule_microtask.dart:52:5)
#20     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:118:13)
#21     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:175:5)
```

## flutter doctor

```
[✓] Flutter (Channel stable, v1.12.13+hotfix.5, on Linux, locale en_US.UTF-8)
    • Flutter version 1.12.13+hotfix.5 at /home/device-farm/flutter
    • Framework revision 27321ebbad (2 weeks ago), 2019-12-10 18:15:01 -0800
    • Engine revision 2994f7e1e6
    • Dart version 2.7.0

[!] Android toolchain - develop for Android devices (Android SDK version 21.1.1)
    • Android SDK at /opt/dev/android-sdk-linux
    • Android NDK location not configured (optional; useful for native profiling support)
    ✗ Flutter requires Android SDK 28 and the Android BuildTools 28.0.3
      To update using sdkmanager, run:
        "/opt/dev/android-sdk-linux/tools/bin/sdkmanager" "platforms;android-28" "build-tools;28.0.3"
      or visit https://flutter.dev/setup/#android-setup for detailed instructions.
    ✗ Android license status unknown.
      Try re-installing or updating your Android SDK Manager.
      See https://developer.android.com/studio/#downloads or visit https://flutter.dev/setup/#android-setup for detailed instructions.

[!] Android Studio (not installed)
    • Android Studio not found; download from https://developer.android.com/studio/index.html
      (or visit https://flutter.dev/setup/#android-setup for detailed instructions).

[✓] Connected device (1 available)
    • SM N970U1 • R58M78B6WRN • android-arm64 • Android 9 (API 28)

! Doctor found issues in 2 categories.
```

As an added benefit, deleting this file also get rid of this mismatched Flutter repo warning:

> Warning! This package referenced a Flutter repository via the .packages file that is no longer available. The repository from which the 'flutter' tool is currently executing will be used instead.
>   running Flutter tool: /home/device-farm/flutter
>   previous reference  : /home/cirrus/sdks/flutter
> This can happen if you deleted or moved your copy of the Flutter repository, or if it was on a volume that is no longer mounted or has been mounted at a different location. Please check your system path to verify that you are running the expected version (run 'flutter --version' to see which flutter is on your path).

