### PR TITLE
Check if other devices in spec are available

### DIFF
--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -35,7 +35,7 @@ bool isValidConfig(Config config, bool isIosPoolTypeActive) {
           .firstWhere((device) => device == sylphDevice, orElse: () => null);
       if (jobDevice != null) {
         if (jobDevice.availability == 'BUSY' || jobDevice.availability == 'TEMPORARY_NOT_AVAILABLE') {
-          printError('Error: device: \'$jobDevice\' \'$sylphDevice\' is busy.');
+          printError('Error: device: \'$jobDevice\' is busy.');
           // If no devices are available then quit.
           if (config.getDevicesInSuite(testSuite.name).last.name == jobDevice.name && matchingSylphDevices.length == 0){
             printError('No available devices. Application will now quit.');

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -34,17 +34,22 @@ bool isValidConfig(Config config, bool isIosPoolTypeActive) {
       final jobDevice = allJobDevices
           .firstWhere((device) => device == sylphDevice, orElse: () => null);
       if (jobDevice != null) {
-        if (jobDevice.availability == 'BUSY') {
-          printError('Error: device: \'$jobDevice\' is busy.');
-          exit(1);
-        }
+        if (jobDevice.availability == 'BUSY' || jobDevice.availability == 'TEMPORARY_NOT_AVAILABLE') {
+          printError('Error: device: \'$jobDevice\' \'$sylphDevice\' is busy.');
+          // If no devices are available then quit.
+          if (config.getDevicesInSuite(testSuite.name).last.name == jobDevice.name && matchingSylphDevices.length == 0){
+            printError('No available devices. Application will now quit.');
+            exit(1);
+          }
+        } else {
         matchingSylphDevices.add(jobDevice);
+        }
       } else {
         printError('Error: No match found for $sylphDevice.');
         missingSylphDevices.add(sylphDevice);
       }
     }
-  }
+    }
 
   // check for valid pool types
   final isPoolTypesValid = config.isValidPoolTypes();


### PR DESCRIPTION
Small change to check if another device is available, rather than the entire job dying. 

Issue: If any 1 of the devices in the spec is `BUSY` or `TEMPORARY_NOT_AVAILABLE` the entire script died. 

Change: Skip the unavailable devices and continue with tests. If no devices are available the tests will exit.