### PR TITLE
Added override of flutter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ To enable testing on a flavor add the following to your sylph.yaml:
 flavor: <name of flavor>
 ```
 
+## Flutter version
+
+Sylph will default to flutter version `v1.12.13+hotfix.8-stable` to execute the tests in AWS but this can be overriden by setting the `FLUTTER_VERSION` environment variable to the version of your choice.
+
 # Configuring a CI Environment for _Sylph_
 In addition to running from the command line, _Sylph_ also runs in a CI environment.
 

--- a/lib/resources/test_spec.yaml
+++ b/lib/resources/test_spec.yaml
@@ -29,7 +29,6 @@ phases:
 
       # install flutter
       - echo "Install flutter"
-      - FLUTTER_VERSION='v1.12.13+hotfix.8-stable'
       - >-
         if [ $DEVICEFARM_DEVICE_PLATFORM_NAME = "Android" ];
         then

--- a/lib/src/resources.dart
+++ b/lib/src/resources.dart
@@ -29,6 +29,7 @@ const kAWSCredentialsEnvVars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'];
 
 // substitute names
 const kAppIdentifier = 'APP_IDENTIFIER';
+const kFlutterVersion = 'FLUTTER_VERSION';
 
 /// Unpacks resources found in package into [tmpDir].
 /// Appium template is used to deliver tests.
@@ -43,7 +44,8 @@ Future<void> unpackResources(String tmpDir, bool isIosPoolTypeActive,
       '$tmpDir/$kAppiumTemplateZip');
 
   // unpack Appium test spec
-  await unpackFile(kAppiumTestSpecName, tmpDir);
+  final testSpecNameVals = { 'FLUTTER_VERSION': getFlutterVersion() };
+  await unpackFile(kAppiumTestSpecName, tmpDir, nameVals: testSpecNameVals);
 
   // unpack scripts
   await unpackScripts(tmpDir);
@@ -138,3 +140,9 @@ String getIosAppIdentifier(String appDir) {
   final iOSConfigStr = fs.file(kIosConfigPath).readAsStringSync();
   return RegExp(regExp).firstMatch(iOSConfigStr)[1];
 }
+
+/// Gets the predefined or overriden flutter version to use
+String getFlutterVersion() {
+  const defaultVersion = 'v1.12.13+hotfix.8-stable';
+  return platform.environment[kFlutterVersion] ?? defaultVersion;
+} 


### PR DESCRIPTION
# Intention

To allow users to override the flutter version by providing an environment variable `FLUTTER_VERSION`.

## Details
Same thing as in https://github.com/mmcc007/sylph/pull/106 but I approached it slightly differently replacing the environment variable in the script with a fixed variable, I think that's what the script would do.

I'm happy to make sure tests work etc if I can get a hint to where and how to run them.